### PR TITLE
Add 'none' changelog provider

### DIFF
--- a/renderspec
+++ b/renderspec
@@ -68,6 +68,8 @@ def _get_changelog(changelog_provider, v_old, v_new):
         if provider == 'gh':
             owner, repo = params.split(',', 2)
             changes = _get_changelog_github(owner, repo, v_old, v_new)
+        elif provider == 'none':
+            changes = []
         else:
             raise Exception("Invalid changelog-provider '%s'" % (provider))
     return changes
@@ -229,7 +231,7 @@ if __name__ == '__main__':
            os.path.exists(changes_file):
             print("Version changed: '%s' -> '%s'"
                   % (old_spec_version, new_spec_version))
-            changes = ['update to version %s:' % new_spec_version]
+            changes = ['update to version %s' % new_spec_version]
             changes_new_version = _get_changelog(
                 args['changelog_provider'], old_spec_version, new_spec_version)
             changes.append(changes_new_version)

--- a/renderspec.service
+++ b/renderspec.service
@@ -39,6 +39,7 @@
       A changelog provider with parameters (separated by comma).
       Currently supported:
       - github: "gh,owner,repository" (e.g. "gh,openstack,oslo.config")
+      - none: "none," (e.g. "none,")
     </description>
   </parameter>
   <parameter name="changelog-email">


### PR DESCRIPTION
When using 'none' as changelog provider, just add an entry that the
package was update to a new version.